### PR TITLE
This PR fixes a logical error in data checksum validation. Without this fix, the function returns None instead of True when no checksum is provided, which could cause silent failures in data integrity checks.

### DIFF
--- a/download_data.py
+++ b/download_data.py
@@ -93,7 +93,7 @@ def checksum_data(private, raise_error=False):
 
         return data_checksum == local_checksum
     else:
-        True
+        return True
 
 
 def download_from_osf(private, username=None, password=None):


### PR DESCRIPTION
## Purpose
Fixes a bug where `checksum_data` returns `None` instead of `True` when `data_checksum` is `None`.

## Changes
- Added `return True` in the `else` block of `checksum_data` to ensure correct validation.

## Testing
- Validated locally by setting `data_checksum = None` and confirming `checksum_data` returns `True`.
- Ensured existing checksum validation logic remains unaffected.